### PR TITLE
[FRIC-90] substaks now show name when created in transaction

### DIFF
--- a/frontend/src/views/SubtaskForm.vue
+++ b/frontend/src/views/SubtaskForm.vue
@@ -189,7 +189,7 @@ export default {
     async logAction () {
       var trans = {
         initals: 'K.A',
-        action: 'K.A created subtask ' + this.form.name
+        action: 'K.A created subtask ' + this.form.title
       }
       LogServices.logAction(trans)
         .then(response => {


### PR DESCRIPTION
You can now see the name of the subtask that was created
![Screen Shot 2020-10-29 at 1 55 08 PM](https://user-images.githubusercontent.com/35210520/97625621-5beb7300-19ee-11eb-85ef-4c7db5c46b1d.png)
