### PR TITLE
[FRIC-117] rename the breadcrumbs to analyst where appropriate

### DIFF
--- a/frontend/src/views/Findings.vue
+++ b/frontend/src/views/Findings.vue
@@ -63,7 +63,7 @@ export default {
   computed: {
     titleStack () {
       return [
-        'Lead Analyst',
+        'Analyst',
         'Findings'
       ]
     }

--- a/frontend/src/views/Subtasks.vue
+++ b/frontend/src/views/Subtasks.vue
@@ -54,7 +54,7 @@ export default {
   computed: {
     titleStack () {
       return [
-        'Lead Analyst',
+        'Analyst',
         'Subtasks'
       ]
     }

--- a/frontend/src/views/Tasks.vue
+++ b/frontend/src/views/Tasks.vue
@@ -92,7 +92,7 @@ export default {
   computed: {
     titleStack () {
       return [
-        'Lead Analyst',
+        'Analyst',
         'Task'
       ]
     }


### PR DESCRIPTION
The ones left as lead analyst make sense. Like only leads can create an event and systems, can configure content and archive things